### PR TITLE
Version-stable R and packages

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -9,13 +9,16 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Setup R
-        uses: r-lib/actions/setup-r@master
-
+      - name: Setup version-stable R 3.6.3
+        uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: '3.6.3'
+        env:
+          CRAN: https://mran.microsoft.com/snapshot/2020-04-12"
       - name: Query dependencies
         run: |
           install.packages("remotes")
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "depends.Rds", version = 2)
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), "depends.Rds")
         shell: Rscript {0}
 
       - name: Cache R packages

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           r-version: '3.6.3'
         env:
-          CRAN: https://mran.microsoft.com/snapshot/2020-04-12"
+          CRAN: https://mran.microsoft.com/snapshot/2020-04-12
       - name: Query dependencies
         run: |
           install.packages("remotes")


### PR DESCRIPTION
Using R 3.6.3 and 2020-04-12 MRAN snapshot to avoid surprises for the duration of contest, also in view of the upcoming R 4.0.0 release.