### PR TITLE
Improve `title` and `author` in example/instruction YAML.

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-a-contribution.md
+++ b/.github/ISSUE_TEMPLATE/submit-a-contribution.md
@@ -10,8 +10,8 @@ Submit your contributions by filling the following information
 
 ``` yaml
 # Contribution's title, author, abstract
-title: An Awesome COVID-19 Contribution
-author: The Author
+title: An Awesome COVID-19 Contribution # title case
+author: An Author, Another Author # comma-separated
 abstract: |
   Provide a short abstract with a brief description of your contribution and its
   main features (max 800 characters, including spaces). The usage of publicly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ Each participant is requested to provide the following information in YAML forma
 
 ``` yaml
 # Contribution's title, author, abstract
-title: An Awesome COVID-19 Contribution
-author: The Author
+title: An Awesome COVID-19 Contribution # title case
+author: An Author, Another Author # comma-separated
 abstract: |
   Provide a short abstract with a brief description of your contribution and its
   main features (max 800 characters, including spaces). The usage of publicly

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ Gallery](https://milano-r.github.io/erum2020-covidr-contest)
 
 ``` yaml
 # Contribution's title, author, abstract
-title: An Awesome COVID-19 Contribution
-author: The Author
+title: An Awesome COVID-19 Contribution # title case
+author: An Author, Another Author # comma-separated
 abstract: |
   Provide a short abstract with a brief description of your contribution and its
   main features (max 800 characters, including spaces). The usage of publicly

--- a/contest/contributions/.example.yml
+++ b/contest/contributions/.example.yml
@@ -1,6 +1,6 @@
 # Contribution's title, author, abstract
-title: An Awesome COVID-19 Contribution
-author: The Author
+title: An Awesome COVID-19 Contribution # title case
+author: An Author, Another Author # comma-separated
 abstract: |
   Provide a short abstract with a brief description of your contribution and its
   main features (max 800 characters, including spaces). The usage of publicly

--- a/contest/contributions/author-contribution-example.yml
+++ b/contest/contributions/author-contribution-example.yml
@@ -1,5 +1,5 @@
 title: CovidR Contribution Example
-author: The Author
+author: An Author, Another Author
 abstract: |
   Short abstract with a brief description of the contribution and its main
   features (max 800 characters, including spaces).


### PR DESCRIPTION
- Title-case
- Comma-separated authors

Also closes #26 